### PR TITLE
Created EmbeddedReactiveMongoConfig depends on embeddedMongoServer, which will be used to running MongoDB Junit tests or in memory database at runtime.

### DIFF
--- a/src/main/java/org/sharma/aarav/spring/boot/reference/data/config/EmbeddedReactiveMongoConfig.java
+++ b/src/main/java/org/sharma/aarav/spring/boot/reference/data/config/EmbeddedReactiveMongoConfig.java
@@ -1,0 +1,53 @@
+package org.sharma.aarav.spring.boot.reference.data.config;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.data.mongodb.config.AbstractReactiveMongoConfiguration;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.mapping.event.LoggingEventListener;
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import org.springframework.core.env.Environment;
+
+@EnableAutoConfiguration(exclude = { DataSourceAutoConfiguration.class , MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
+@EnableReactiveMongoRepositories(basePackages = "org.sharma.aarav.spring.boot.reference.data")
+@AutoConfigureAfter(EmbeddedMongoAutoConfiguration.class)
+public class EmbeddedReactiveMongoConfig extends AbstractReactiveMongoConfiguration {
+
+    private final Environment environment;
+
+    public EmbeddedReactiveMongoConfig(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Bean
+    public LoggingEventListener mongoEventListener() {
+        return new LoggingEventListener();
+    }
+
+    @Override
+    @Bean
+    @DependsOn("embeddedMongoServer")
+    public MongoClient reactiveMongoClient() {
+        int port = environment.getProperty("local.mongo.port", Integer.class);
+        return MongoClients.create(String.format("mongodb://localhost:%d", port));
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return "embeded_db";
+    }
+
+    @Bean
+    public ReactiveMongoTemplate reactiveMongoTemplate() {
+        return new ReactiveMongoTemplate(reactiveMongoClient(), getDatabaseName());
+    }
+
+}


### PR DESCRIPTION
Created EmbeddedReactiveMongoConfig depends on embeddedMongoServer, which will be used to running MongoDB Junit tests or in memory database at runtime.
